### PR TITLE
Add stacked X toast recreation at /13

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+By submitting a pull request to this project, you agree to license your contribution under the terms of the MIT License.
+
+Please read our [Contributor License Agreement and other Contributing Guidelines](CONTRIBUTING.md).
+
+## Goal
+
+<!-- What problem does this PR solve, or what does it add? -->
+
+## Screenshots
+
+<!-- Screen recordings or images. For animation PRs, a short clip is especially helpful. -->
+
+## What I changed and why
+
+<!-- Bullet list of changes and the reasoning behind each. -->
+
+## How I convinced myself this is right
+
+<!-- How you tested or verified: build, manual QA, reduced-motion, etc. -->
+
+## What I'm not doing here
+
+<!-- Explicit non-goals or follow-ups left for later. -->
+
+## LLM use disclosure
+
+<!--
+Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
+If none, state "None".
+Trivial tab-completion doesn't need to be disclosed.
+-->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing
+
+Thanks for contributing to **animations**.
+
+## Contributor License Agreement
+
+By submitting a pull request to this project, you agree to license your contribution under the terms of the [MIT License](LICENSE).
+
+You represent that you have the right to submit the work and that your contribution is your original work, or work you have permission to submit under these terms.
+
+## Development
+
+```bash
+pnpm install
+pnpm dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) and navigate to the demo route you are working on (for example `/13`).
+
+## Code quality
+
+Before opening a pull request, run:
+
+```bash
+pnpm lint
+pnpm build
+```
+
+CI runs Biome on `./src` for every pull request.
+
+## Pull requests
+
+Use the pull request template. Include:
+
+- A clear **goal**
+- **Screenshots** or a short screen recording for visual or animation changes
+- **What changed and why**
+- How you **verified** the change
+- **Non-goals** — what you intentionally left out
+- **LLM use disclosure** if applicable
+
+Keep PRs focused. Prefer one demo or concern per pull request when possible.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Osa
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/biome.json
+++ b/biome.json
@@ -1,52 +1,54 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.8.3/schema.json",
-  "formatter": {
-    "enabled": true,
-    "formatWithErrors": true,
-    "ignore": [],
-    "attributePosition": "auto",
-    "indentStyle": "tab",
-    "indentWidth": 2,
-    "lineWidth": 50,
-    "lineEnding": "lf"
-  },
-  "javascript": {
-    "formatter": {
-      "arrowParentheses": "always",
-      "bracketSameLine": false,
-      "bracketSpacing": true,
-      "jsxQuoteStyle": "double",
-      "quoteProperties": "asNeeded",
-      "semicolons": "always",
-      "trailingCommas": "all",
-      "quoteStyle": "double"
-    }
-  },
-  "json": {
-    "formatter": {
-      "trailingCommas": "none"
-    }
-  },
-  "vcs": {
-    "clientKind": "git",
-    "defaultBranch": "main",
-    "enabled": true,
-    "root": ".",
-    "useIgnoreFile": true
-  },
-  "organizeImports": {
-    "enabled": false
-  },
-  "linter": {
-    "enabled": true,
-    "rules": {
-      "recommended": true,
-      "correctness": {
-        "noUnusedImports": "error"
-      },
-      "nursery": {
-        "useSortedClasses": "error"
-      }
-    }
-  }
+	"$schema": "https://biomejs.dev/schemas/2.5.1/schema.json",
+	"formatter": {
+		"enabled": true,
+		"formatWithErrors": true,
+		"includes": ["**"],
+		"attributePosition": "auto",
+		"indentStyle": "tab",
+		"indentWidth": 2,
+		"lineWidth": 50,
+		"lineEnding": "lf"
+	},
+	"javascript": {
+		"formatter": {
+			"arrowParentheses": "always",
+			"bracketSameLine": false,
+			"bracketSpacing": true,
+			"jsxQuoteStyle": "double",
+			"quoteProperties": "asNeeded",
+			"semicolons": "always",
+			"trailingCommas": "all",
+			"quoteStyle": "double"
+		}
+	},
+	"json": {
+		"formatter": {
+			"trailingCommas": "none"
+		}
+	},
+	"vcs": {
+		"clientKind": "git",
+		"defaultBranch": "main",
+		"enabled": true,
+		"root": ".",
+		"useIgnoreFile": true
+	},
+	"assist": {
+		"actions": {
+			"source": { "organizeImports": "off" }
+		}
+	},
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"preset": "recommended",
+			"correctness": {
+				"noUnusedImports": "error"
+			},
+			"nursery": {
+				"useSortedClasses": "error"
+			}
+		}
+	}
 }

--- a/content/13-propose-a-toast.md
+++ b/content/13-propose-a-toast.md
@@ -1,0 +1,210 @@
+# How to Recreate X's Stacked Toast Notifications
+
+**Demo:** [animations.glamboyosa/13](https://animations.glamboyosa/13) · **Source:** [github.com/glamboyosa/animations](https://github.com/glamboyosa/animations) · **Reference:** [Benji Taylor — "I'd like to propose a toast"](https://x.com/benjitaylor/status/2069168413306667353)
+
+---
+
+When Benji Taylor posted [a short motion piece](https://x.com/benjitaylor/status/2069168413306667353) titled *"I'd like to propose a toast"*, the joke was obvious. He was proposing a redesign of X's notification toasts — the little cards that slide in when someone DMs you, reposts you, or likes your post.
+
+What made it land wasn't a Figma mockup. It was motion. Three glassy cards, stacked in 3D, each one a different notification type, cycling with weight and depth. The meta copy inside the toasts was funny. The *feel* was the pitch.
+
+This article walks through how I recreated that stack in React and Motion — what I copied from the original, what I got wrong on the first pass, and the motion details that actually matter if you want it to feel premium instead of "CSS homework."
+
+## Table of Contents
+
+- [What the original does](#what-the-original-does)
+- [What my first version got wrong](#what-my-first-version-got-wrong)
+- [Prerequisites](#prerequisites)
+- [What you will learn](#what-you-will-learn)
+- [Push stack, not carousel](#push-stack-not-carousel)
+- [Glass surfaces without hard borders](#glass-surfaces-without-hard-borders)
+- [Timing that matches the OG clip](#timing-that-matches-the-og-clip)
+- [Avatars with type badges](#avatars-with-type-badges)
+- [Accessibility](#accessibility)
+- [What I deliberately did not build](#what-i-deliberately-did-not-build)
+- [Conclusion](#conclusion)
+
+## What the original does
+
+Benji's clip is roughly eight seconds on a black background. **Three** notification cards are visible at once — never four. The sequence cycles through four notification types (repost → like → follow → message), but only three occupy the stack at any moment.
+
+1. **Repost** — avatar with green repost badge overlaid
+2. **Like** — avatar with pink heart badge overlaid
+3. **Follow** — avatar with follow badge overlaid
+4. **DM** — avatar with blue online dot
+
+The front card is full size at the **top** of the stack. Cards behind it are smaller, lower down, softer, and slightly blurred. When a new notification arrives, it **drops in from above**, the existing cards shuffle back one slot, and the rearmost card exits downward.
+
+That's a **push stack** — not a carousel that rotates which card is "active." The canvas is pure `#000`. No title. No button.
+
+## What my first version got wrong
+
+I screen-recorded v1 next to Benji's MP4 and the deviance was obvious. Frame-by-frame comparison surfaced four real problems:
+
+| Issue | v1 (wrong) | OG (right) |
+| --- | --- | --- |
+| **Motion model** | Rotated `activeIndex` — all four cards shuffled every 2.4s | New toast pushes in; oldest exits; only three visible |
+| **Timing** | 350ms snappy spring on every cycle | ~780ms ease-out push, ~2s between beats |
+| **Stack depth** | `-20px` offset, 4 cards fighting for space | `-30px` offset, 3 cards, stronger scale falloff |
+| **Chrome** | Title + "Next toast" button on screen | Pure black canvas |
+| **Stack anchor** | Front at bottom, enters from below | Front at top, enters from above |
+| **Surface** | `rgba(32,32,32)` on `#000` — muddy, low contrast | Lifted gray gradient on `#0b0b0d` + radial glow |
+
+| **Card layout** | Icon-only for repost/like rows | Avatar on every type with badge overlay |
+
+v2 fixed the carousel but still anchored the stack at the bottom — new toasts slid **up**, which reads backwards next to the OG. It also put near-black glass on pure `#000`, which kills contrast. Both are feel problems, not tuning problems.
+
+## Prerequisites
+
+To follow along, you should have:
+
+- Basic React and TypeScript
+- Familiarity with CSS `transform` and `opacity`
+- [Motion](https://motion.dev/) installed — this demo uses `motion/react` and `AnimatePresence`
+
+You do not need Sonner, Radix, or X's actual toast implementation. This is a standalone recreation for learning.
+
+## What you will learn
+
+- Why a **push stack** beats an `activeIndex` carousel for this effect
+- How to use `AnimatePresence` for enter/shift/exit in one gesture
+- Matching OG timing with tweens (`0.78s` push, `2s` interval) instead of fast springs
+- Avatar + badge overlays for every notification type
+- When subtle `blur()` on back slots is worth the tradeoff in a showcase demo
+
+## Push stack, not carousel
+
+The core state is a **queue of three entries**, not a modular index into four fixed cards.
+
+```ts
+type StackEntry = { key: string; toast: Toast };
+
+const [stack, setStack] = useState<StackEntry[]>(initialStack);
+
+function pushToast() {
+  const toast = TOAST_SEQUENCE[sequenceIndex % TOAST_SEQUENCE.length];
+  const key = `${toast.id}-${pushCounter.current++}`;
+
+  setStack((current) => [
+    { key, toast },                        // enters at front
+    ...current.slice(0, VISIBLE_COUNT - 1), // previous front/middle shift back
+  ]);                                      // previous back exits via AnimatePresence
+}
+```
+
+Each entry gets a unique `key` so Motion can track enter, shift, and exit independently.
+
+**Position** drives transform — front at top, back cards fall **down**:
+
+```ts
+function slotStyle(position: number) {
+  const y = position * 26;
+  const scale = 1 - position * 0.052;
+
+  return {
+    opacity: position === 0 ? 1 : position === 1 ? 0.76 : 0.5,
+    transform: `translate3d(0, ${y}px, 0) scale(${scale})`,
+    filter: position === 1 ? "blur(0.5px)" : position >= 2 ? "blur(1px)" : "none",
+    zIndex: 30 - position,
+  };
+}
+```
+
+Note `translate3d` — explicit GPU layer. `transformOrigin: center top` anchors the stack from above, matching how the OG reads.
+
+**Enter** from above (new toast drops in):
+
+```ts
+initial: {
+  opacity: 0,
+  transform: "translate3d(0, -44px, 0) scale(0.97)",
+}
+```
+
+**Exit** downward (oldest toast at the back):
+
+```ts
+exit: {
+  opacity: 0,
+  transform: "translate3d(0, 64px, 0) scale(0.9)",
+}
+```
+
+Wrap the stack in `AnimatePresence` so the exiting card animates out instead of vanishing.
+
+## Glass surfaces without hard borders
+
+Dark glass on pure `#000` only works if the card is **translucent**, not opaque. The OG uses semi-transparent fill + heavy `backdrop-filter` + a hairline top highlight — not a lifted gray gradient or off-black canvas.
+
+```ts
+background: "rgba(30, 30, 32, 0.78)",
+backdropFilter: "blur(32px) saturate(1.2)",
+boxShadow: [
+  "0 0 0 1px rgba(255, 255, 255, 0.09)",
+  "inset 0 1px 0 rgba(255, 255, 255, 0.08)",
+  "0 16px 48px rgba(0, 0, 0, 0.55)",
+].join(", "),
+```
+
+Back cards in the stack also carry **heavy blur** (`2px` / `5px`) — that's what sells depth in the OG frames, not just opacity falloff.
+
+## Timing that matches the OG clip
+
+The original is ~8 seconds with ~1.7–2 seconds between pushes. Motion should read clearly without dragging.
+
+| Phase | Duration | Easing |
+| --- | --- | --- |
+| **Push** (existing cards shift back) | `520ms` | `cubic-bezier(0.32, 0.72, 0, 1)` — iOS drawer curve |
+| **Enter** (new card from above) | `560ms` | `cubic-bezier(0.23, 1, 0.32, 1)` — strong ease-out |
+| **Exit** (back card leaves) | `420ms` | drawer curve |
+| **Interval** between pushes | `1700ms` | — |
+
+An earlier pass used `780ms` tweens — closer in spirit but too sluggish on loop. The OG is cinematic, not sleepy. If it feels slow, shorten the tween before touching the interval.
+
+## Avatars with type badges
+
+In the OG, every notification type shows an avatar. The type is communicated by a small badge on the avatar's bottom-right corner — green repost, pink heart, white follow plus, blue DM dot.
+
+v1 only showed an avatar on DMs and used standalone icons for repost/like. That was a layout miss, not just a motion one. Matching the badge pattern makes each card read faster and aligns with the reference frames.
+
+## Accessibility
+
+```ts
+const reduced = useReducedMotion() ?? false;
+```
+
+When reduced motion is on:
+
+- Stack offsets shrink (`-10px` instead of `-30px`)
+- Animated blur is removed
+- Push interval slows to `3.2s`
+
+The full viewport button has `aria-label="Show next toast"`. Reduced motion means gentler motion, not zero feedback.
+
+## What I deliberately did not build
+
+This is a motion study, not a toast library.
+
+- **No Sonner integration** — different problem (queuing, swipe, pause-on-hover)
+- **No swipe-to-dismiss** — next craft layer if this shipped for real
+- **No pixel-perfect clone** — same choreography and timing, different usernames
+- **No local avatars** — X pfps via [unavatar](https://unavatar.io), The Weeknd via Spotify CDN
+
+## Conclusion
+
+The first version failed because I optimized for "toast component" patterns when the reference is a **motion study**. Carousels shuffle; push stacks breathe. Fast springs snap; slow tweens glide.
+
+The fixes that mattered most, in order:
+
+1. Push stack with `AnimatePresence` enter/exit
+2. Three visible cards, not four
+3. **Top-anchored stack** — enter from above, exit downward
+4. **Translucent glass on `#000`** — not opaque fill or off-black canvas
+5. ~520ms tween + 1.7s interval
+6. Avatar badges on every type
+
+The live demo is at **[animations.glamboyosa/13](https://animations.glamboyosa/13)**. Record it next to [Benji's original](https://x.com/benjitaylor/status/2069168413306667353) and compare frame by frame. The difference should be timing and choreography, not "why does mine feel cheap."
+
+---
+
+*osa · [animations.glamboyosa](https://animations.glamboyosa) · [blog.glamboyosa.xyz](https://blog.glamboyosa.xyz)*

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,14 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+	images: {
+		remotePatterns: [
+			{ protocol: "https", hostname: "unavatar.io" },
+			{ protocol: "https", hostname: "image-cdn-ak.spotifycdn.com" },
+			{ protocol: "https", hostname: "i.scdn.co" },
+			{ protocol: "https", hostname: "pbs.twimg.com" },
+			{ protocol: "https", hostname: "i.pravatar.cc" },
+		],
+	},
+};
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "vaul": "^0.9.1"
   },
   "devDependencies": {
-    "@biomejs/biome": "1.8.3",
+    "@biomejs/biome": "2.5.1",
     "@types/node": "^20",
     "@types/react": "^19.1.4",
     "@types/react-dom": "^19.1.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,8 +58,8 @@ importers:
         version: 0.9.1(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     devDependencies:
       '@biomejs/biome':
-        specifier: 1.8.3
-        version: 1.8.3
+        specifier: 2.5.1
+        version: 2.5.1
       '@types/node':
         specifier: ^20
         version: 20.12.10
@@ -95,59 +95,55 @@ packages:
     resolution: {integrity: sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==}
     engines: {node: '>=6.9.0'}
 
-  '@biomejs/biome@1.8.3':
-    resolution: {integrity: sha512-/uUV3MV+vyAczO+vKrPdOW0Iaet7UnJMU4bNMinggGJTAnBPjCoLEYcyYtYHNnUNYlv4xZMH6hVIQCAozq8d5w==}
+  '@biomejs/biome@2.5.1':
+    resolution: {integrity: sha512-IXWLCxKmae+rI7LOHS1B3EbVisQ6GRAWbhN9msa6KjNCyFWrvKZWR4oUdinaNssrV852OrSHuSPa95h1GPJc7Q==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@1.8.3':
-    resolution: {integrity: sha512-9DYOjclFpKrH/m1Oz75SSExR8VKvNSSsLnVIqdnKexj6NwmiMlKk94Wa1kZEdv6MCOHGHgyyoV57Cw8WzL5n3A==}
+  '@biomejs/cli-darwin-arm64@2.5.1':
+    resolution: {integrity: sha512-npqDzvqv7vFaWRiNN1Te71siRgPaqS9MpqgYCdP/CrUbkJ7ApezaeaKjueKHRN/JH/6lRjJQAHi8acQDCAz22w==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@1.8.3':
-    resolution: {integrity: sha512-UeW44L/AtbmOF7KXLCoM+9PSgPo0IDcyEUfIoOXYeANaNXXf9mLUwV1GeF2OWjyic5zj6CnAJ9uzk2LT3v/wAw==}
+  '@biomejs/cli-darwin-x64@2.5.1':
+    resolution: {integrity: sha512-RgwTqPAM8g2tn1j+b5oRjF/DbSBX8a4gwojtuG9XuhfK7GgomvZ9+T+tqjXiVbjLEeGJOoL6VEk8mvRTVeSybw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@1.8.3':
-    resolution: {integrity: sha512-9yjUfOFN7wrYsXt/T/gEWfvVxKlnh3yBpnScw98IF+oOeCYb5/b/+K7YNqKROV2i1DlMjg9g/EcN9wvj+NkMuQ==}
+  '@biomejs/cli-linux-arm64-musl@2.5.1':
+    resolution: {integrity: sha512-WMcvMLgByyTqVxGlq918NBBYliq9FRR9GAQVETHb+VjGVqXCZFfHlZHC1FX4ibuYY/Hg6TJE3rHU0xVrdJXNRw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
-  '@biomejs/cli-linux-arm64@1.8.3':
-    resolution: {integrity: sha512-fed2ji8s+I/m8upWpTJGanqiJ0rnlHOK3DdxsyVLZQ8ClY6qLuPc9uehCREBifRJLl/iJyQpHIRufLDeotsPtw==}
+  '@biomejs/cli-linux-arm64@2.5.1':
+    resolution: {integrity: sha512-yhV35CzZh38VyMvTEXi3JTjxZBs++oCKK9KG8vB6VI5+uvQvZNR3BFWEKKzuOmx9DJJj7sQpZ4LQJcmbGTs3+Q==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@1.8.3':
-    resolution: {integrity: sha512-UHrGJX7PrKMKzPGoEsooKC9jXJMa28TUSMjcIlbDnIO4EAavCoVmNQaIuUSH0Ls2mpGMwUIf+aZJv657zfWWjA==}
+  '@biomejs/cli-linux-x64-musl@2.5.1':
+    resolution: {integrity: sha512-ANTowtlLmPYm5yeMckWY8Xzb9Ix+JJP3tgHR/n6xRj1VWyIzzWtfRfih9hv9VmClwadpBvZduISZIbBsIlYG3A==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
-  '@biomejs/cli-linux-x64@1.8.3':
-    resolution: {integrity: sha512-I8G2QmuE1teISyT8ie1HXsjFRz9L1m5n83U1O6m30Kw+kPMPSKjag6QGUn+sXT8V+XWIZxFFBoTDEDZW2KPDDw==}
+  '@biomejs/cli-linux-x64@2.5.1':
+    resolution: {integrity: sha512-J/7uHSX7NfoYDI7HijAkd8lnQIOrRb2W7j3X+tw4R+N5ExvXGsyXFiGdQcfcxfOmNQmZVSQOCDk757fwpzqQcg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@1.8.3':
-    resolution: {integrity: sha512-J+Hu9WvrBevfy06eU1Na0lpc7uR9tibm9maHynLIoAjLZpQU3IW+OKHUtyL8p6/3pT2Ju5t5emReeIS2SAxhkQ==}
+  '@biomejs/cli-win32-arm64@2.5.1':
+    resolution: {integrity: sha512-zgXnKNgWPC4iPF7Y1lR3STUeCUuZRpD6IiOrC7TZTlh0Lx6FiVUT05myuMQHQ9D+1cc7uyMldi4forE6lp0ivQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@1.8.3':
-    resolution: {integrity: sha512-/PJ59vA1pnQeKahemaQf4Nyj7IKUvGQSc3Ze1uIGi+Wvr1xF7rGobSrAAG01T/gUDG21vkDsZYM03NAmPiVkqg==}
+  '@biomejs/cli-win32-x64@2.5.1':
+    resolution: {integrity: sha512-6uxpR9hvaglANkZemeSiN/FhYgkGasrEGn267eXIWvjrjJ2LhDlk251IhjVJq6MXzkV2/bcXwLwSroLyPtqRZg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -212,85 +208,72 @@ packages:
     resolution: {integrity: sha512-IVfGJa7gjChDET1dK9SekxFFdflarnUB8PwW8aGwEoF3oAsSDuNUTYS+SKDOyOJxQyDC1aPFMuRYLoDInyV9Ew==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.1.0':
     resolution: {integrity: sha512-s8BAd0lwUIvYCJyRdFqvsj+BJIpDBSxs6ivrOPm/R7piTs5UIwY5OjXrP2bqXC9/moGsyRa37eYWYCOGVXxVrA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.1.0':
     resolution: {integrity: sha512-tiXxFZFbhnkWE2LA8oQj7KYR+bWBkiV2nilRldT7bqoEZ4HiDOcePr9wVDAZPi/Id5fT1oY9iGnDq20cwUz8lQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.1.0':
     resolution: {integrity: sha512-xukSwvhguw7COyzvmjydRb3x/09+21HykyapcZchiCUkTThEQEOMtBj9UhkaBRLuBrgLFzQ2wbxdeCCJW/jgJA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.1.0':
     resolution: {integrity: sha512-yRj2+reB8iMg9W5sULM3S74jVS7zqSzHG3Ol/twnAAkAhnGQnpjj6e4ayUz7V+FpKypwgs82xbRdYtchTTUB+Q==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.1.0':
     resolution: {integrity: sha512-jYZdG+whg0MDK+q2COKbYidaqW/WTz0cc1E+tMAusiDygrM4ypmSCjOJPmFTvHHJ8j/6cAGyeDWZOsK06tP33w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.1.0':
     resolution: {integrity: sha512-wK7SBdwrAiycjXdkPnGCPLjYb9lD4l6Ze2gSdAGVZrEL05AOUJESWU2lhlC+Ffn5/G+VKuSm6zzbQSzFX/P65A==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.1':
     resolution: {integrity: sha512-kX2c+vbvaXC6vly1RDf/IWNXxrlxLNpBVWkdpRq5Ka7OOKj6nr66etKy2IENf6FtOgklkg9ZdGpEu9kwdlcwOQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.1':
     resolution: {integrity: sha512-anKiszvACti2sGy9CirTlNyk7BjjZPiML1jt2ZkTdcvpLU1YH6CXwRAZCA2UmRXnhiIftXQ7+Oh62Ji25W72jA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.1':
     resolution: {integrity: sha512-7s0KX2tI9mZI2buRipKIw2X1ufdTeaRgwmRabt5bi9chYfhur+/C1OXg3TKg/eag1W+6CCWLVmSauV1owmRPxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.1':
     resolution: {integrity: sha512-wExv7SH9nmoBW3Wr2gvQopX1k8q2g5V5Iag8Zk6AVENsjwd+3adjwxtp3Dcu2QhOXr8W9NusBU6XcQUohBZ5MA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.1':
     resolution: {integrity: sha512-DfvyxzHxw4WGdPiTF0SOHnm11Xv4aQexvqhRDAoD00MzHekAj9a/jADXeXYCDFH/DzYruwHbXU7uz+H+nWmSOQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.1':
     resolution: {integrity: sha512-pax/kTR407vNb9qaSIiWVnQplPcGU8LRIJpDT5o8PdAx5aAA7AS3X9PS8Isw1/WfqgQorPotjrZL3Pqh6C5EBg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.1':
     resolution: {integrity: sha512-YDybQnYrLQfEpzGOQe7OKcyLUCML4YOXl428gOOzBgN6Gw0rv8dpsJ7PqTHxBnXnwXr8S1mYFSLSa727tpz0xg==}
@@ -354,28 +337,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.3.5':
     resolution: {integrity: sha512-k8aVScYZ++BnS2P69ClK7v4nOu702jcF9AIHKu6llhHEtBSmM2zkPGl9yoqbSU/657IIIb0QHpdxEr0iW9z53A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.3.5':
     resolution: {integrity: sha512-2xYU0DI9DGN/bAHzVwADid22ba5d/xrbrQlr2U+/Q5WkFUzeL0TDR963BdrtLS/4bMmKZGptLeg6282H/S2i8A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.3.5':
     resolution: {integrity: sha512-TRYIqAGf1KCbuAB0gjhdn5Ytd8fV+wJSM2Nh2is/xEqR8PZHxfQuaiNhoF50XfY90sNpaRMaGhF6E+qjV1b9Tg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.3.5':
     resolution: {integrity: sha512-h04/7iMEUSMY6fDGCvdanKqlO1qYvzNxntZlCzfE8i5P0uqzVQWQquU1TIhlz0VqGQGXLrFDuTJVONpqGqjGKQ==}
@@ -2189,39 +2168,39 @@ snapshots:
     dependencies:
       regenerator-runtime: 0.14.1
 
-  '@biomejs/biome@1.8.3':
+  '@biomejs/biome@2.5.1':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 1.8.3
-      '@biomejs/cli-darwin-x64': 1.8.3
-      '@biomejs/cli-linux-arm64': 1.8.3
-      '@biomejs/cli-linux-arm64-musl': 1.8.3
-      '@biomejs/cli-linux-x64': 1.8.3
-      '@biomejs/cli-linux-x64-musl': 1.8.3
-      '@biomejs/cli-win32-arm64': 1.8.3
-      '@biomejs/cli-win32-x64': 1.8.3
+      '@biomejs/cli-darwin-arm64': 2.5.1
+      '@biomejs/cli-darwin-x64': 2.5.1
+      '@biomejs/cli-linux-arm64': 2.5.1
+      '@biomejs/cli-linux-arm64-musl': 2.5.1
+      '@biomejs/cli-linux-x64': 2.5.1
+      '@biomejs/cli-linux-x64-musl': 2.5.1
+      '@biomejs/cli-win32-arm64': 2.5.1
+      '@biomejs/cli-win32-x64': 2.5.1
 
-  '@biomejs/cli-darwin-arm64@1.8.3':
+  '@biomejs/cli-darwin-arm64@2.5.1':
     optional: true
 
-  '@biomejs/cli-darwin-x64@1.8.3':
+  '@biomejs/cli-darwin-x64@2.5.1':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@1.8.3':
+  '@biomejs/cli-linux-arm64-musl@2.5.1':
     optional: true
 
-  '@biomejs/cli-linux-arm64@1.8.3':
+  '@biomejs/cli-linux-arm64@2.5.1':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@1.8.3':
+  '@biomejs/cli-linux-x64-musl@2.5.1':
     optional: true
 
-  '@biomejs/cli-linux-x64@1.8.3':
+  '@biomejs/cli-linux-x64@2.5.1':
     optional: true
 
-  '@biomejs/cli-win32-arm64@1.8.3':
+  '@biomejs/cli-win32-arm64@2.5.1':
     optional: true
 
-  '@biomejs/cli-win32-x64@1.8.3':
+  '@biomejs/cli-win32-x64@2.5.1':
     optional: true
 
   '@emnapi/runtime@1.4.3':
@@ -3163,7 +3142,7 @@ snapshots:
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.57.0)
       eslint-plugin-react: 7.34.1(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.0)
@@ -3186,8 +3165,8 @@ snapshots:
       debug: 4.3.4
       enhanced-resolve: 5.16.1
       eslint: 8.57.0
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.4
       is-core-module: 2.13.1
@@ -3198,7 +3177,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -3209,7 +3188,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
@@ -3219,7 +3198,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.13.1
       is-glob: 4.0.3

--- a/src/app/13/page.tsx
+++ b/src/app/13/page.tsx
@@ -1,0 +1,330 @@
+"use client";
+
+import Image from "next/image";
+import {
+	useEffect,
+	useMemo,
+	useState,
+} from "react";
+import {
+	motion,
+	useReducedMotion,
+	type Transition,
+} from "motion/react";
+
+type ToastType = "message" | "retweet" | "like";
+
+type Toast = {
+	id: string;
+	type: ToastType;
+	username: string;
+	headline: string;
+	preview?: string;
+	avatar: string;
+};
+
+const TOASTS: Toast[] = [
+	{
+		id: "dm",
+		type: "message",
+		username: "glamboyosa",
+		headline: "@glamboyosa sent you a message",
+		preview: "ok but we need to ship this toast",
+		avatar: "https://unavatar.io/x/glamboyosa",
+	},
+	{
+		id: "rt",
+		type: "retweet",
+		username: "genehackerman",
+		headline: "@genehackerman reposted",
+		preview: "stacked toasts are actually insane",
+		avatar: "https://unavatar.io/x/genehackerman",
+	},
+	{
+		id: "like",
+		type: "like",
+		username: "theweeknd",
+		headline: "@theweeknd liked your post",
+		preview: "blinding lights on repeat",
+		avatar:
+			"https://image-cdn-ak.spotifycdn.com/image/ab67616100005174c1719ac9e6a75c1c25835018",
+	},
+	{
+		id: "random",
+		type: "like",
+		username: "nova_ui",
+		headline: "@nova_ui liked your post",
+		preview: "why does this feel so premium",
+		avatar: "https://i.pravatar.cc/150?u=nova_ui",
+	},
+];
+
+const SPRING: Transition = {
+	type: "spring",
+	duration: 0.55,
+	bounce: 0.12,
+};
+
+const ENTER_SPRING: Transition = {
+	type: "spring",
+	duration: 0.65,
+	bounce: 0.08,
+};
+
+function stackStyle(
+	position: number,
+	reduced: boolean,
+) {
+	if (reduced) {
+		return {
+			opacity: position === 0 ? 1 : 0.35,
+			transform: `translateY(${position * -8}px) scale(${1 - position * 0.03})`,
+			filter: "blur(0px)",
+			zIndex: 10 - position,
+		};
+	}
+
+	return {
+		opacity: 1 - position * 0.22,
+		transform: `translateY(${position * -20}px) scale(${1 - position * 0.045})`,
+		filter:
+			position > 0
+				? `blur(${position}px)`
+				: "blur(0px)",
+		zIndex: 10 - position,
+	};
+}
+
+function RetweetIcon() {
+	return (
+		<svg
+			width="18"
+			height="18"
+			viewBox="0 0 24 24"
+			fill="currentColor"
+			className="shrink-0 text-[#00ba7c]"
+			aria-hidden
+		>
+			<title>Repost</title>
+			<path d="M4.5 3.88l4.432 4.14-1.02 1.015L3.5 5.5v7h7v-1.5H5.5V3.88zm15 16.24l-4.432-4.14 1.02-1.015L20.5 18.5v-7h-7v1.5h4.5v5.62z" />
+		</svg>
+	);
+}
+
+function HeartIcon() {
+	return (
+		<svg
+			width="18"
+			height="18"
+			viewBox="0 0 24 24"
+			fill="currentColor"
+			className="shrink-0 text-[#f91880]"
+			aria-hidden
+		>
+			<title>Like</title>
+			<path d="M12 21.638h-.014C9.403 21.59 1.95 14.856 1.95 8.478c0-3.064 2.525-5.754 5.403-5.754 2.29 0 3.83 1.58 4.646 2.73.814-1.148 2.354-2.73 4.645-2.73 2.88 0 5.404 2.69 5.404 5.755 0 6.376-7.454 13.11-10.037 13.157H12z" />
+		</svg>
+	);
+}
+
+function ToastAvatar({
+	src,
+	showOnline,
+}: {
+	src: string;
+	showOnline?: boolean;
+}) {
+	return (
+		<div className="relative shrink-0">
+			<Image
+				src={src}
+				alt=""
+				width={40}
+				height={40}
+				className="size-10 rounded-full object-cover outline outline-1 outline-white/10"
+				unoptimized
+			/>
+			{showOnline ? (
+				<span className="-right-0.5 absolute bottom-0 size-3 rounded-full border-2 border-[#1a1a1a] bg-[#1d9bf0]" />
+			) : null}
+		</div>
+	);
+}
+
+function ToastCard({
+	toast,
+	position,
+	reduced,
+	introComplete,
+	toastIndex,
+}: {
+	toast: Toast;
+	position: number;
+	reduced: boolean;
+	introComplete: boolean;
+	toastIndex: number;
+}) {
+	const stack = stackStyle(position, reduced);
+
+	return (
+		<motion.article
+			layout
+			initial={{
+				opacity: 0,
+				transform: "translateY(32px) scale(0.95)",
+				filter: "blur(6px)",
+			}}
+			animate={{
+				opacity: stack.opacity,
+				transform: stack.transform,
+				filter: stack.filter,
+			}}
+			transition={{
+				...(introComplete
+					? SPRING
+					: ENTER_SPRING),
+				delay: introComplete
+					? 0
+					: toastIndex * 0.11,
+			}}
+			style={{
+				zIndex: stack.zIndex,
+				transformOrigin: "center bottom",
+			}}
+			className="pointer-events-none absolute inset-x-0 bottom-0 mx-auto w-full max-w-[400px]"
+		>
+			<div
+				className="rounded-2xl px-4 py-3.5"
+				style={{
+					background: "rgba(28, 28, 28, 0.82)",
+					backdropFilter: "blur(24px)",
+					boxShadow: [
+						"0 0 0 1px rgba(255, 255, 255, 0.08)",
+						"0 16px 48px rgba(0, 0, 0, 0.55)",
+						"0 4px 12px rgba(0, 0, 0, 0.35)",
+					].join(", "),
+				}}
+			>
+				<div className="flex items-start gap-3">
+					{toast.type === "message" ? (
+						<ToastAvatar
+							src={toast.avatar}
+							showOnline
+						/>
+					) : toast.type === "retweet" ? (
+						<RetweetIcon />
+					) : (
+						<HeartIcon />
+					)}
+
+					<div className="min-w-0 flex-1 pt-0.5">
+						<motion.p
+							initial={false}
+							animate={{
+								opacity: 1,
+								filter: "blur(0px)",
+							}}
+							className="text-pretty text-[15px] text-white/90 leading-snug"
+						>
+							{toast.headline}
+						</motion.p>
+						{toast.preview ? (
+							<motion.p
+								initial={false}
+								animate={{
+									opacity: 1,
+									filter: "blur(0px)",
+								}}
+								className="mt-1 truncate text-[15px] text-white/45 leading-snug"
+							>
+								{toast.preview}
+							</motion.p>
+						) : null}
+					</div>
+				</div>
+			</div>
+		</motion.article>
+	);
+}
+
+export default function ProposeAToast() {
+	const reduced = useReducedMotion() ?? false;
+	const [activeIndex, setActiveIndex] =
+		useState(0);
+	const [introComplete, setIntroComplete] =
+		useState(false);
+
+	const ordered = useMemo(() => {
+		return TOASTS.map((toast, index) => {
+			const position =
+				(index - activeIndex + TOASTS.length) %
+				TOASTS.length;
+			return { toast, position };
+		}).sort((a, b) => b.position - a.position);
+	}, [activeIndex]);
+
+	useEffect(() => {
+		const introTimer = setTimeout(
+			() => setIntroComplete(true),
+			80 + TOASTS.length * 110 + 600,
+		);
+		return () => clearTimeout(introTimer);
+	}, []);
+
+	useEffect(() => {
+		if (!introComplete) return;
+
+		const interval = setInterval(
+			() => {
+				setActiveIndex(
+					(prev) => (prev + 1) % TOASTS.length,
+				);
+			},
+			reduced ? 4000 : 2400,
+		);
+
+		return () => clearInterval(interval);
+	}, [introComplete, reduced]);
+
+	return (
+		<div className="flex min-h-screen flex-col items-center justify-center bg-black antialiased">
+			<p className="mb-16 text-balance px-6 text-center text-sm text-white/30">
+				I&apos;d like to propose a toast
+			</p>
+
+			<div
+				className="relative h-[220px] w-full max-w-[440px] px-5"
+				style={{
+					perspective: reduced
+						? undefined
+						: "1200px",
+				}}
+			>
+				{ordered.map(({ toast, position }) => (
+					<ToastCard
+						key={toast.id}
+						toast={toast}
+						position={position}
+						reduced={reduced}
+						introComplete={introComplete}
+						toastIndex={TOASTS.findIndex(
+							(t) => t.id === toast.id,
+						)}
+					/>
+				))}
+			</div>
+
+			<button
+				type="button"
+				onClick={() =>
+					setActiveIndex(
+						(prev) => (prev + 1) % TOASTS.length,
+					)
+				}
+				className="mt-20 min-h-10 min-w-10 rounded-full px-5 py-2.5 text-sm text-white/40 transition-[transform,opacity,color] duration-200 ease-out hover:text-white/70 active:scale-[0.96]"
+			>
+				Next toast
+			</button>
+		</div>
+	);
+}

--- a/src/app/13/page.tsx
+++ b/src/app/13/page.tsx
@@ -1,113 +1,171 @@
 "use client";
 
 import Image from "next/image";
+import { IBM_Plex_Sans } from "next/font/google";
 import {
+	useCallback,
 	useEffect,
-	useMemo,
+	useRef,
 	useState,
 } from "react";
 import {
+	AnimatePresence,
 	motion,
 	useReducedMotion,
 	type Transition,
 } from "motion/react";
 
-type ToastType = "message" | "retweet" | "like";
+const toastFont = IBM_Plex_Sans({
+	subsets: ["latin"],
+	weight: ["400", "500", "600"],
+	display: "swap",
+});
+
+type ToastType =
+	| "message"
+	| "retweet"
+	| "like"
+	| "follow";
 
 type Toast = {
 	id: string;
 	type: ToastType;
-	username: string;
 	headline: string;
-	preview?: string;
+	preview: string;
 	avatar: string;
 };
 
-const TOASTS: Toast[] = [
+type StackEntry = {
+	key: string;
+	toast: Toast;
+};
+
+const TOAST_SEQUENCE: Toast[] = [
 	{
-		id: "dm",
-		type: "message",
-		username: "glamboyosa",
-		headline: "@glamboyosa sent you a message",
-		preview: "ok but we need to ship this toast",
-		avatar: "https://unavatar.io/x/glamboyosa",
-	},
-	{
-		id: "rt",
+		id: "repost",
 		type: "retweet",
-		username: "genehackerman",
-		headline: "@genehackerman reposted",
+		headline: "@genehackerman reposted your post",
 		preview: "stacked toasts are actually insane",
 		avatar: "https://unavatar.io/x/genehackerman",
 	},
 	{
 		id: "like",
 		type: "like",
-		username: "theweeknd",
 		headline: "@theweeknd liked your post",
 		preview: "blinding lights on repeat",
 		avatar:
 			"https://image-cdn-ak.spotifycdn.com/image/ab67616100005174c1719ac9e6a75c1c25835018",
 	},
 	{
-		id: "random",
-		type: "like",
-		username: "nova_ui",
-		headline: "@nova_ui liked your post",
-		preview: "why does this feel so premium",
+		id: "follow",
+		type: "follow",
+		headline: "@nova_ui followed you",
+		preview: "you now follow each other",
 		avatar: "https://i.pravatar.cc/150?u=nova_ui",
+	},
+	{
+		id: "dm",
+		type: "message",
+		headline: "@glamboyosa sent you a message",
+		preview: "ok but we need to ship this toast",
+		avatar: "https://unavatar.io/x/glamboyosa",
 	},
 ];
 
-const CYCLE_SPRING: Transition = {
-	type: "spring",
-	duration: 0.35,
-	bounce: 0,
+const VISIBLE_COUNT = 3;
+const PUSH_INTERVAL_MS = 1700;
+
+const PUSH_TRANSITION: Transition = {
+	type: "tween",
+	duration: 0.52,
+	ease: [0.32, 0.72, 0, 1],
 };
 
-const ENTER_SPRING: Transition = {
-	type: "spring",
-	duration: 0.5,
-	bounce: 0.08,
+const ENTER_TRANSITION: Transition = {
+	type: "tween",
+	duration: 0.56,
+	ease: [0.23, 1, 0.32, 1],
 };
 
-const TEXT_ENTER: Transition = {
-	type: "spring",
-	duration: 0.35,
-	bounce: 0,
+const EXIT_TRANSITION: Transition = {
+	type: "tween",
+	duration: 0.42,
+	ease: [0.32, 0.72, 0, 1],
 };
 
-function stackStyle(
+function createEntry(
+	toast: Toast,
+	suffix: string,
+): StackEntry {
+	return { key: `${toast.id}-${suffix}`, toast };
+}
+
+function initialStack(): StackEntry[] {
+	return TOAST_SEQUENCE.slice(
+		0,
+		VISIBLE_COUNT,
+	).map((toast, index) =>
+		createEntry(toast, `init-${index}`),
+	);
+}
+
+function slotStyle(
 	position: number,
 	reduced: boolean,
 ) {
 	if (reduced) {
 		return {
-			opacity: position === 0 ? 1 : 0.35,
-			transform: `translateY(${position * -8}px) scale(${1 - position * 0.03})`,
-			zIndex: 10 - position,
+			opacity:
+				position === 0
+					? 1
+					: position === 1
+						? 0.55
+						: 0.3,
+			transform: `translate3d(0, ${position * 10}px, 0) scale(${1 - position * 0.028})`,
+			filter: "none",
+			zIndex: 30 - position,
 		};
 	}
 
+	const y = position * 22;
+	const scale = 1 - position * 0.048;
+
 	return {
-		opacity: 1 - position * 0.22,
-		transform: `translateY(${position * -20}px) scale(${1 - position * 0.045})`,
-		zIndex: 10 - position,
+		opacity:
+			position === 0
+				? 1
+				: position === 1
+					? 0.82
+					: 0.58,
+		transform: `translate3d(0, ${y}px, 0) scale(${scale})`,
+		filter:
+			position === 1
+				? "blur(2px)"
+				: position >= 2
+					? "blur(5px)"
+					: "none",
+		zIndex: 30 - position,
 	};
 }
 
-function RetweetIcon() {
+function RepostIcon() {
 	return (
 		<svg
-			width="18"
-			height="18"
+			width="13"
+			height="13"
 			viewBox="0 0 24 24"
-			fill="currentColor"
-			className="shrink-0 text-[#00ba7c]"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2.35"
+			strokeLinecap="round"
+			strokeLinejoin="round"
 			aria-hidden
 		>
 			<title>Repost</title>
-			<path d="M4.5 3.88l4.432 4.14-1.02 1.015L3.5 5.5v7h7v-1.5H5.5V3.88zm15 16.24l-4.432-4.14 1.02-1.015L20.5 18.5v-7h-7v1.5h4.5v5.62z" />
+			<path d="M17 2l4 4-4 4" />
+			<path d="M3 11v-1a4 4 0 0 1 4-4h14" />
+			<path d="M7 22l-4-4 4-4" />
+			<path d="M21 13v1a4 4 0 0 1-4 4H3" />
 		</svg>
 	);
 }
@@ -115,11 +173,10 @@ function RetweetIcon() {
 function HeartIcon() {
 	return (
 		<svg
-			width="18"
-			height="18"
+			width="14"
+			height="14"
 			viewBox="0 0 24 24"
 			fill="currentColor"
-			className="shrink-0 text-[#f91880]"
 			aria-hidden
 		>
 			<title>Like</title>
@@ -128,12 +185,76 @@ function HeartIcon() {
 	);
 }
 
+function FollowIcon() {
+	return (
+		<svg
+			width="14"
+			height="14"
+			viewBox="0 0 24 24"
+			fill="currentColor"
+			aria-hidden
+		>
+			<title>Follow</title>
+			<path d="M10 4H14V10H20V14H14V20H10V14H4V10H10V4Z" />
+		</svg>
+	);
+}
+
+function TypeBadge({
+	type,
+}: {
+	type: ToastType;
+}) {
+	const className =
+		"absolute -bottom-0.5 -right-0.5 flex items-center justify-center rounded-full border-2 border-black";
+
+	if (type === "message") {
+		return (
+			<span
+				className={`${className} size-[18px] bg-[#1d9bf0]`}
+				aria-hidden
+			/>
+		);
+	}
+
+	if (type === "retweet") {
+		return (
+			<span
+				className={`${className} size-[22px] bg-[#0f0f0f] text-[#00ba7c]`}
+				aria-hidden
+			>
+				<RepostIcon />
+			</span>
+		);
+	}
+
+	if (type === "like") {
+		return (
+			<span
+				className={`${className} size-[18px] bg-[#0f0f0f] text-[#f91880]`}
+				aria-hidden
+			>
+				<HeartIcon />
+			</span>
+		);
+	}
+
+	return (
+		<span
+			className={`${className} size-[18px] bg-[#0f0f0f] text-white`}
+			aria-hidden
+		>
+			<FollowIcon />
+		</span>
+	);
+}
+
 function ToastAvatar({
 	src,
-	showOnline,
+	type,
 }: {
 	src: string;
-	showOnline?: boolean;
+	type: ToastType;
 }) {
 	return (
 		<div className="relative shrink-0">
@@ -145,154 +266,88 @@ function ToastAvatar({
 				className="size-10 rounded-full object-cover outline outline-1 outline-white/10"
 				unoptimized
 			/>
-			{showOnline ? (
-				<span className="-right-0.5 absolute bottom-0 size-3 rounded-full border-2 border-[#1a1a1a] bg-[#1d9bf0]" />
-			) : null}
+			<TypeBadge type={type} />
 		</div>
 	);
 }
 
-function ToastText({
-	headline,
-	preview,
-	staggerIn,
-	baseDelay,
-}: {
-	headline: string;
-	preview?: string;
-	staggerIn: boolean;
-	baseDelay: number;
-}) {
-	if (!staggerIn) {
-		return (
-			<>
-				<p className="text-pretty text-[15px] text-white/90 leading-snug">
-					{headline}
-				</p>
-				{preview ? (
-					<p className="mt-1 truncate text-[15px] text-white/45 leading-snug">
-						{preview}
-					</p>
-				) : null}
-			</>
-		);
-	}
-
-	return (
-		<>
-			<motion.p
-				initial={{
-					opacity: 0,
-					transform: "translateY(6px)",
-				}}
-				animate={{
-					opacity: 1,
-					transform: "translateY(0)",
-				}}
-				transition={{
-					...TEXT_ENTER,
-					delay: baseDelay + 0.05,
-				}}
-				className="text-pretty text-[15px] text-white/90 leading-snug"
-			>
-				{headline}
-			</motion.p>
-			{preview ? (
-				<motion.p
-					initial={{
-						opacity: 0,
-						transform: "translateY(6px)",
-					}}
-					animate={{
-						opacity: 1,
-						transform: "translateY(0)",
-					}}
-					transition={{
-						...TEXT_ENTER,
-						delay: baseDelay + 0.12,
-					}}
-					className="mt-1 truncate text-[15px] text-white/45 leading-snug"
-				>
-					{preview}
-				</motion.p>
-			) : null}
-		</>
-	);
-}
-
 function ToastCard({
-	toast,
+	entry,
 	position,
 	reduced,
-	introComplete,
-	toastIndex,
+	isEntering,
 }: {
-	toast: Toast;
+	entry: StackEntry;
 	position: number;
 	reduced: boolean;
-	introComplete: boolean;
-	toastIndex: number;
+	isEntering: boolean;
 }) {
-	const stack = stackStyle(position, reduced);
-	const cardDelay = introComplete
-		? 0
-		: toastIndex * 0.11;
+	const slot = slotStyle(position, reduced);
 
 	return (
 		<motion.article
-			initial={{
-				opacity: 0,
-				transform: "translateY(32px) scale(0.95)",
-			}}
+			layout={false}
+			initial={
+				isEntering
+					? {
+							opacity: 0,
+							transform:
+								"translate3d(0, -44px, 0) scale(0.97)",
+							filter: "none",
+						}
+					: false
+			}
 			animate={{
-				opacity: stack.opacity,
-				transform: stack.transform,
+				opacity: slot.opacity,
+				transform: slot.transform,
+				filter: slot.filter,
 			}}
-			transition={{
-				...(introComplete
-					? CYCLE_SPRING
-					: ENTER_SPRING),
-				delay: cardDelay,
+			exit={{
+				opacity: 0,
+				transform:
+					"translate3d(0, 64px, 0) scale(0.9)",
+				filter: reduced ? "none" : "blur(0.8px)",
+				transition: EXIT_TRANSITION,
 			}}
+			transition={
+				isEntering
+					? ENTER_TRANSITION
+					: PUSH_TRANSITION
+			}
 			style={{
-				zIndex: stack.zIndex,
-				transformOrigin: "center bottom",
+				zIndex: slot.zIndex,
+				transformOrigin: "center top",
+				willChange: "transform, opacity",
 			}}
-			className="pointer-events-none absolute inset-x-0 bottom-0 mx-auto w-full max-w-[400px]"
+			className="pointer-events-none absolute inset-x-0 top-0 mx-auto w-full max-w-[420px]"
 		>
 			<div
-				className="rounded-2xl px-4 py-3.5"
+				className="rounded-[22px] px-4 py-3.5"
 				style={{
-					background: "rgba(28, 28, 28, 0.82)",
-					backdropFilter: "blur(24px)",
+					background: "rgba(30, 30, 32, 0.78)",
+					backdropFilter:
+						"blur(32px) saturate(1.2)",
+					WebkitBackdropFilter:
+						"blur(32px) saturate(1.2)",
 					boxShadow: [
-						"0 0 0 1px rgba(255, 255, 255, 0.08)",
+						"0 0 0 1px rgba(255, 255, 255, 0.09)",
+						"inset 0 1px 0 rgba(255, 255, 255, 0.08)",
 						"0 16px 48px rgba(0, 0, 0, 0.55)",
-						"0 4px 12px rgba(0, 0, 0, 0.35)",
 					].join(", "),
 				}}
 			>
 				<div className="flex items-start gap-3">
-					{toast.type === "message" ? (
-						<ToastAvatar
-							src={toast.avatar}
-							showOnline
-						/>
-					) : toast.type === "retweet" ? (
-						<RetweetIcon />
-					) : (
-						<HeartIcon />
-					)}
-
+					<ToastAvatar
+						src={entry.toast.avatar}
+						type={entry.toast.type}
+					/>
 					<div className="min-w-0 flex-1 pt-0.5">
-						<ToastText
-							headline={toast.headline}
-							preview={toast.preview}
-							staggerIn={
-								!introComplete && position === 0
-							}
-							baseDelay={cardDelay}
-						/>
+						<p className="text-pretty font-semibold text-[#f7f9f9] text-[15px] leading-snug">
+							{entry.toast.headline}
+						</p>
+						<p className="mt-1 truncate text-[#8b8b90] text-[15px] leading-snug">
+							{entry.toast.preview}
+						</p>
 					</div>
 				</div>
 			</div>
@@ -302,82 +357,70 @@ function ToastCard({
 
 export default function ProposeAToast() {
 	const reduced = useReducedMotion() ?? false;
-	const [activeIndex, setActiveIndex] =
-		useState(0);
-	const [introComplete, setIntroComplete] =
-		useState(false);
+	const [stack, setStack] =
+		useState<StackEntry[]>(initialStack);
+	const [sequenceIndex, setSequenceIndex] =
+		useState(VISIBLE_COUNT);
+	const [enteringKey, setEnteringKey] = useState<
+		string | null
+	>(null);
+	const pushCounter = useRef(0);
 
-	const ordered = useMemo(() => {
-		return TOASTS.map((toast, index) => {
-			const position =
-				(index - activeIndex + TOASTS.length) %
-				TOASTS.length;
-			return { toast, position };
-		}).sort((a, b) => b.position - a.position);
-	}, [activeIndex]);
+	const pushToast = useCallback(() => {
+		const toast =
+			TOAST_SEQUENCE[
+				sequenceIndex % TOAST_SEQUENCE.length
+			];
+		const suffix = String(pushCounter.current++);
+		const key = `${toast.id}-${suffix}`;
+
+		setSequenceIndex((index) => index + 1);
+		setEnteringKey(key);
+		setStack((current) => [
+			{ key, toast },
+			...current.slice(0, VISIBLE_COUNT - 1),
+		]);
+	}, [sequenceIndex]);
 
 	useEffect(() => {
-		const introTimer = setTimeout(
-			() => setIntroComplete(true),
-			80 + TOASTS.length * 110 + 500,
+		if (!enteringKey) return;
+		const timer = setTimeout(
+			() => setEnteringKey(null),
+			620,
 		);
-		return () => clearTimeout(introTimer);
-	}, []);
+		return () => clearTimeout(timer);
+	}, [enteringKey]);
 
 	useEffect(() => {
-		if (!introComplete) return;
-
 		const interval = setInterval(
-			() => {
-				setActiveIndex(
-					(prev) => (prev + 1) % TOASTS.length,
-				);
-			},
-			reduced ? 4000 : 2400,
+			pushToast,
+			reduced ? 2800 : PUSH_INTERVAL_MS,
 		);
-
 		return () => clearInterval(interval);
-	}, [introComplete, reduced]);
+	}, [pushToast, reduced]);
 
 	return (
-		<div className="flex min-h-screen flex-col items-center justify-center bg-black antialiased">
-			<p className="mb-16 text-balance px-6 text-center text-sm text-white/30">
-				I&apos;d like to propose a toast
-			</p>
-
-			<div
-				className="relative h-[220px] w-full max-w-[440px] px-5"
-				style={{
-					perspective: reduced
-						? undefined
-						: "1200px",
-				}}
-			>
-				{ordered.map(({ toast, position }) => (
-					<ToastCard
-						key={toast.id}
-						toast={toast}
-						position={position}
-						reduced={reduced}
-						introComplete={introComplete}
-						toastIndex={TOASTS.findIndex(
-							(t) => t.id === toast.id,
-						)}
-					/>
-				))}
+		<button
+			type="button"
+			aria-label="Show next toast"
+			onClick={pushToast}
+			className={`${toastFont.className} flex min-h-screen w-full items-center justify-center bg-black tracking-[-0.01em] antialiased active:scale-[0.995] motion-reduce:active:scale-100`}
+		>
+			<div className="relative h-[230px] w-full max-w-[440px] px-5">
+				<AnimatePresence initial={false}>
+					{stack.map((entry, position) => (
+						<ToastCard
+							key={entry.key}
+							entry={entry}
+							position={position}
+							reduced={reduced}
+							isEntering={
+								entry.key === enteringKey
+							}
+						/>
+					))}
+				</AnimatePresence>
 			</div>
-
-			<button
-				type="button"
-				onClick={() =>
-					setActiveIndex(
-						(prev) => (prev + 1) % TOASTS.length,
-					)
-				}
-				className="mt-20 min-h-10 min-w-10 rounded-full px-5 py-2.5 text-sm text-white/40 transition-[transform,opacity,color] duration-200 ease-out hover:text-white/70 active:scale-[0.96]"
-			>
-				Next toast
-			</button>
-		</div>
+		</button>
 	);
 }

--- a/src/app/13/page.tsx
+++ b/src/app/13/page.tsx
@@ -59,16 +59,22 @@ const TOASTS: Toast[] = [
 	},
 ];
 
-const SPRING: Transition = {
+const CYCLE_SPRING: Transition = {
 	type: "spring",
-	duration: 0.55,
-	bounce: 0.12,
+	duration: 0.35,
+	bounce: 0,
 };
 
 const ENTER_SPRING: Transition = {
 	type: "spring",
-	duration: 0.65,
+	duration: 0.5,
 	bounce: 0.08,
+};
+
+const TEXT_ENTER: Transition = {
+	type: "spring",
+	duration: 0.35,
+	bounce: 0,
 };
 
 function stackStyle(
@@ -79,7 +85,6 @@ function stackStyle(
 		return {
 			opacity: position === 0 ? 1 : 0.35,
 			transform: `translateY(${position * -8}px) scale(${1 - position * 0.03})`,
-			filter: "blur(0px)",
 			zIndex: 10 - position,
 		};
 	}
@@ -87,10 +92,6 @@ function stackStyle(
 	return {
 		opacity: 1 - position * 0.22,
 		transform: `translateY(${position * -20}px) scale(${1 - position * 0.045})`,
-		filter:
-			position > 0
-				? `blur(${position}px)`
-				: "blur(0px)",
 		zIndex: 10 - position,
 	};
 }
@@ -151,6 +152,74 @@ function ToastAvatar({
 	);
 }
 
+function ToastText({
+	headline,
+	preview,
+	staggerIn,
+	baseDelay,
+}: {
+	headline: string;
+	preview?: string;
+	staggerIn: boolean;
+	baseDelay: number;
+}) {
+	if (!staggerIn) {
+		return (
+			<>
+				<p className="text-pretty text-[15px] text-white/90 leading-snug">
+					{headline}
+				</p>
+				{preview ? (
+					<p className="mt-1 truncate text-[15px] text-white/45 leading-snug">
+						{preview}
+					</p>
+				) : null}
+			</>
+		);
+	}
+
+	return (
+		<>
+			<motion.p
+				initial={{
+					opacity: 0,
+					transform: "translateY(6px)",
+				}}
+				animate={{
+					opacity: 1,
+					transform: "translateY(0)",
+				}}
+				transition={{
+					...TEXT_ENTER,
+					delay: baseDelay + 0.05,
+				}}
+				className="text-pretty text-[15px] text-white/90 leading-snug"
+			>
+				{headline}
+			</motion.p>
+			{preview ? (
+				<motion.p
+					initial={{
+						opacity: 0,
+						transform: "translateY(6px)",
+					}}
+					animate={{
+						opacity: 1,
+						transform: "translateY(0)",
+					}}
+					transition={{
+						...TEXT_ENTER,
+						delay: baseDelay + 0.12,
+					}}
+					className="mt-1 truncate text-[15px] text-white/45 leading-snug"
+				>
+					{preview}
+				</motion.p>
+			) : null}
+		</>
+	);
+}
+
 function ToastCard({
 	toast,
 	position,
@@ -165,27 +234,25 @@ function ToastCard({
 	toastIndex: number;
 }) {
 	const stack = stackStyle(position, reduced);
+	const cardDelay = introComplete
+		? 0
+		: toastIndex * 0.11;
 
 	return (
 		<motion.article
-			layout
 			initial={{
 				opacity: 0,
 				transform: "translateY(32px) scale(0.95)",
-				filter: "blur(6px)",
 			}}
 			animate={{
 				opacity: stack.opacity,
 				transform: stack.transform,
-				filter: stack.filter,
 			}}
 			transition={{
 				...(introComplete
-					? SPRING
+					? CYCLE_SPRING
 					: ENTER_SPRING),
-				delay: introComplete
-					? 0
-					: toastIndex * 0.11,
+				delay: cardDelay,
 			}}
 			style={{
 				zIndex: stack.zIndex,
@@ -218,28 +285,14 @@ function ToastCard({
 					)}
 
 					<div className="min-w-0 flex-1 pt-0.5">
-						<motion.p
-							initial={false}
-							animate={{
-								opacity: 1,
-								filter: "blur(0px)",
-							}}
-							className="text-pretty text-[15px] text-white/90 leading-snug"
-						>
-							{toast.headline}
-						</motion.p>
-						{toast.preview ? (
-							<motion.p
-								initial={false}
-								animate={{
-									opacity: 1,
-									filter: "blur(0px)",
-								}}
-								className="mt-1 truncate text-[15px] text-white/45 leading-snug"
-							>
-								{toast.preview}
-							</motion.p>
-						) : null}
+						<ToastText
+							headline={toast.headline}
+							preview={toast.preview}
+							staggerIn={
+								!introComplete && position === 0
+							}
+							baseDelay={cardDelay}
+						/>
 					</div>
 				</div>
 			</div>
@@ -266,7 +319,7 @@ export default function ProposeAToast() {
 	useEffect(() => {
 		const introTimer = setTimeout(
 			() => setIntroComplete(true),
-			80 + TOASTS.length * 110 + 600,
+			80 + TOASTS.length * 110 + 500,
 		);
 		return () => clearTimeout(introTimer);
 	}, []);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 import clsx from "clsx";
 import {
@@ -20,7 +20,12 @@ const jac = Jacquard_24({
 const AttributionLink = () => (
 	<span
 		className="underline hover:text-blue-500 cursor-pointer"
-		onClick={() => window.open('https://www.thiings.co/things', '_blank')}
+		onClick={() =>
+			window.open(
+				"https://www.thiings.co/things",
+				"_blank",
+			)
+		}
 	>
 		thiings.co
 	</span>
@@ -233,7 +238,6 @@ export default function Home() {
 				<Link
 					href={"/12"}
 					prefetch={true}
-
 					className="group rounded-lg border border-transparent px-5 py-4 transition-colors hover:border-gray-300 hover:bg-gray-100 hover:dark:border-neutral-700 hover:dark:bg-neutral-800/30"
 				>
 					<h2 className="mb-3 font-semibold text-2xl">
@@ -243,7 +247,25 @@ export default function Home() {
 						</span>
 					</h2>
 					<p className="m-0 max-w-[30ch] text-sm opacity-50">
-						Apple 3D icons animation inspired by Airbnb&apos;s 3D animations with smooth fade transitions. 3D models from <AttributionLink />
+						Apple 3D icons animation inspired by
+						Airbnb&apos;s 3D animations with
+						smooth fade transitions. 3D models
+						from <AttributionLink />
+					</p>
+				</Link>
+				<Link
+					href={"/13"}
+					className="group rounded-lg border border-transparent px-5 py-4 transition-colors hover:border-gray-300 hover:bg-gray-100 hover:dark:border-neutral-700 hover:dark:bg-neutral-800/30"
+				>
+					<h2 className="mb-3 font-semibold text-2xl">
+						13{" "}
+						<span className="inline-block transition-transform group-hover:translate-x-1 motion-reduce:transform-none">
+							-&gt;
+						</span>
+					</h2>
+					<p className="m-0 max-w-[30ch] text-sm opacity-50">
+						X stacked toast notifications by Benji
+						Taylor — glassy 3D card stack
 					</p>
 				</Link>
 			</div>


### PR DESCRIPTION
## Goal

Recreate [Benji Taylor's stacked X toast notifications](https://x.com/benjitaylor/status/2069168413306667353) as an interactive demo at `/13` — glassy push-stack motion, custom cast, and a write-up of the craft decisions along the way.

## Screenshots



## What I changed and why

- **`/13` push-stack demo** — Three visible toasts, top-anchored. New cards enter from above; back cards shift down; oldest exits downward. Matches the spatial logic of the original rather than a carousel shuffle.
- **Visual fidelity** — Pure `#000` background, translucent glass cards (`rgba(30,30,32,0.78)` + `backdrop-filter`), back-card blur for depth, X-style repost/like/follow/DM badges, `#f7f9f9` / `#8b8b90` text on dark surfaces.
- **Motion tuning** — Interruptible Motion tweens (`translate3d` + opacity). Push 520ms, enter 560ms, exit 420ms, 1.7s auto-interval. `transform-origin: center top`. Durations above the 300ms UI budget are intentional for this showcase recreation.
- **Typography** — IBM Plex Sans scoped to the demo for crisper notification-style copy.
- **Interaction** — Full-screen tap advances the stack; `prefers-reduced-motion` drops movement and slows the interval.
- **Custom cast** — `@glamboyosa`, `@genehackerman`, The Weeknd (Spotify avatar), `@nova_ui` rotating through four notification types.
- **Homepage link** — Adds demo 13 to the index grid on this branch.
- **`content/13-propose-a-toast.md`** — FCC-style article documenting iterations, animation review findings, and what we learned matching the OG.
- **Contributor setup** — `LICENSE` (MIT), `CONTRIBUTING.md`, `.github/pull_request_template.md` for future PRs.
- **`next.config.mjs`** — Remote image patterns for unavatar, Spotify CDN, pravatar.
- **Biome v2** — Upgraded to `2.5.1`, migrated `recommended` → `preset: "recommended"` so CI no longer fails on the deprecated config field.

## How I convinced myself this is right

- [x] `pnpm dev` → `/13` loads, auto-cycles, tap advances mid-animation without jank
- [x] Compare against OG clip — direction (push from top), glass depth, badge colors
- [x] `prefers-reduced-motion: reduce` — no translate/blur movement; slower interval
- [x] Avatars and badges render (remote images allowed in `next.config.mjs`)
- [x] `pnpm biome check biome.json` — no `recommended` deprecation error


## What I'm not doing here

- Not redesigning the homepage gallery — that's in `feat/ui-polish` (separate PR).
- Not pixel-perfect Chirp font match (proprietary; IBM Plex Sans is the stand-in).
- Not fixing pre-existing Biome lint issues in older demo files.
- Not including the stashed `/12` middleware preload work.

## LLM use disclosure

